### PR TITLE
V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ PHP library to allow [Zstandard](https://facebook.github.io/zstd/) compression a
 
 ## Dependencies
 
-ZSTD, example installation on Ubuntu:
+ZSTD must be installed on your system. Example installation on Ubuntu:
 
 ```bash
 sudo apt install zstd
-````
+```
 
 ## Installation
 
@@ -36,9 +36,21 @@ use Appoly\ZstdPhp\ZSTD;
 ZSTD::compress('path/to/file', 'path/to/output/file.zst');
 ```
 
+If no output path is provided, the compressed file will be saved with the `.zst` extension added:
+
+```php
+ZSTD::compress('path/to/file'); // Creates path/to/file.zst
+```
+
+For decompression, if no output path is provided, the file will be decompressed in place:
+
+```php
+ZSTD::decompress('path/to/file.zst'); // Creates path/to/file
+```
+
 ### Advanced
 
-Decompress from a stream, and handle the output yourself in chunks. Can be used with custom filesystems etc to minimise memory usage.
+Decompress from a stream, and handle the output yourself in chunks. Can be used with custom filesystems etc to minimize memory usage.
 
 ```php
 use Appoly\ZstdPhp\ZSTD;
@@ -57,7 +69,7 @@ ZSTD::decompressDataFromStream(
 fclose($inputStream);
 ```
 
-Compress from a stream, and handle the output yourself in chunks. Can be used with custom filesystems etc to minimise memory usage.
+Compress from a stream, and handle the output yourself in chunks. Can be used with custom filesystems etc to minimize memory usage.
 
 ```php
 use Appoly\ZstdPhp\ZSTD;
@@ -68,7 +80,7 @@ $outputCallback = function ($outputChunk) {
     echo $outputChunk;
 };
 
-ZSTD::compressDataToStream(
+ZSTD::compressDataFromStream(
     inputStream: $inputStream,
     outputCallback: $outputCallback
 );
@@ -76,10 +88,27 @@ ZSTD::compressDataToStream(
 fclose($inputStream);
 ```
 
+You can also specify a timeout for stream operations:
+
+```php
+ZSTD::compressDataFromStream(
+    inputStream: $inputStream,
+    outputCallback: $outputCallback,
+    timeout: 60.0 // Timeout in seconds
+);
+```
+
+## Exception Handling
+
+The library throws exceptions when operations fail:
+
+- `\Exception` if ZSTD is not installed on the system
+- `\RuntimeException` if compression or decompression processes fail
+
 ## License
 MIT License
 
-Copyright (c) 2023 Appoly Ltd
+Copyright (c) 2025 Appoly Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "appoly/zstd-php",
     "description": "PHP wrapper for zstd",
     "require": {
+        "php": "^8.0",
         "symfony/process": "^6.0"
     },
     "license": "MIT",
@@ -14,6 +15,10 @@
         {
             "name": "John Wedgbury",
             "email": "john@appoly.co.uk"
+        },
+        {
+            "name": "James Merrix",
+            "email": "james@appoly.co.uk"
         }
     ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f25804bbc74070ad2fd2c72d4f4f6b1",
+    "content-hash": "6ae2faa18193fbb4ac5cccc9028fc32e",
     "packages": [
         {
             "name": "symfony/process",
-            "version": "v6.4.0",
+            "version": "v6.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "191703b1566d97a5425dc969e4350d32b8ef17aa"
+                "reference": "3cb242f059c14ae08591c5c4087d1fe443564392"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/191703b1566d97a5425dc969e4350d32b8ef17aa",
-                "reference": "191703b1566d97a5425dc969e4350d32b8ef17aa",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3cb242f059c14ae08591c5c4087d1fe443564392",
+                "reference": "3cb242f059c14ae08591c5c4087d1fe443564392",
                 "shasum": ""
             },
             "require": {
@@ -49,7 +49,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.0"
+                "source": "https://github.com/symfony/process/tree/v6.4.15"
             },
             "funding": [
                 {
@@ -65,16 +65,18 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-17T21:06:49+00:00"
+            "time": "2024-11-06T14:19:14+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {
+        "php": "^8.0"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and documentation of the PHP library for Zstandard compression. The most important changes include updates to the `README.md` file, enhancements to the `ZSTD` class, and modifications to the `composer.json` file.

Documentation Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R11): Clarified installation instructions for ZSTD and added examples for compressing and decompressing files without specifying output paths. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R53)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R111): Added information on specifying timeouts for stream operations and detailed exception handling.

Code Enhancements:
* [`src/ZSTD.php`](diffhunk://#diff-08dcc3943575c848b743625ef2ee31db025e9859adf755fdfdf8a5cda580a37fR6-R145): Refactored the `compress` and `decompress` methods to use the `Process` class for better error handling and added detailed docblocks.
* [`src/ZSTD.php`](diffhunk://#diff-08dcc3943575c848b743625ef2ee31db025e9859adf755fdfdf8a5cda580a37fR6-R145): Introduced a private `runStreamProcess` method to handle stream compression and decompression with improved error handling and timeout support.

Dependency and Metadata Updates:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R5): Updated PHP version requirement to `^8.0` and added a new maintainer. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R5) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R18-R21)